### PR TITLE
gh-139155: Remove "dictionaries are sorted by key" note in pprint docs

### DIFF
--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -22,8 +22,6 @@ The formatted representation keeps objects on a single line if it can, and
 breaks them onto multiple lines if they don't fit within the allowed width,
 adjustable by the *width* parameter defaulting to 80 characters.
 
-Dictionaries are sorted by key before the display is computed.
-
 .. versionchanged:: 3.9
    Added support for pretty-printing :class:`types.SimpleNamespace`.
 


### PR DESCRIPTION
skip news
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--1.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->